### PR TITLE
properly escape PicketLinks REST URL

### DIFF
--- a/common-plugin/src/main/java/org/gatein/sso/plugin/RestCallbackCaller.java
+++ b/common-plugin/src/main/java/org/gatein/sso/plugin/RestCallbackCaller.java
@@ -159,11 +159,11 @@ public class RestCallbackCaller
             String errorMessage = "an Exception occurred trying to encode the POST URL.";
             if (log.isDebugEnabled()) {
                log.debug(errorMessage, e);
-		    } else {
-		       log.error(errorMessage +
-		       " The exception is hidden for security reasons." +
-		       " To see the actual exception, enable DEBUG logging.");
-		    }
+            } else {
+               log.error(errorMessage +
+                        " The exception is hidden for security reasons." +
+                        " To see the actual exception, enable DEBUG logging.");
+            }
             throw new RuntimeException(errorMessage);
          }
 


### PR DESCRIPTION
Fixed a bug which prevented users with a password in PicketLink containing a '%' sign to log in when using CAS. Also, no longer print a problematic URL by default, as it may contain a plain-text password.
